### PR TITLE
Upgrade respect/validation to 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": "^7.0",
         "psr/http-message": "^1.0",
-        "respect/validation": "^1.1"
+        "respect/validation": "^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.3",

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -590,22 +590,22 @@ class Validator implements ValidatorInterface
     protected function storeErrors(NestedValidationException $e, Configuration $config, array $messages = [])
     {
         $errors = [
-            $e->findMessages($this->getRulesNames($config->getValidationRules()))
+            $e->getMessages($this->getRulesNames($config->getValidationRules()))
         ];
 
         // If default messages are defined
         if (!empty($this->defaultMessages)) {
-            $errors[] = $e->findMessages($this->defaultMessages);
+            $errors[] = $e->getMessages($this->defaultMessages);
         }
 
         // If global messages are defined
         if (!empty($messages)) {
-            $errors[] = $e->findMessages($messages);
+            $errors[] = $e->getMessages($messages);
         }
 
         // If individual messages are defined
         if ($config->hasMessages()) {
-            $errors[] = $e->findMessages($config->getMessages());
+            $errors[] = $e->getMessages($config->getMessages());
         }
 
         $this->setErrors($this->mergeMessages($errors), $config->getKey(), $config->getGroup());

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -541,7 +541,7 @@ class Validator implements ValidatorInterface
         if ($validatable instanceof AbstractComposite) {
             $rulesNames = [];
             foreach ($validatable->getRules() as $rule) {
-                array_push($rulesNames, ...$this->getRulesNames($rule instanceof AbstractWrapper ? $rule->getValidatable() : $rule));
+                array_push($rulesNames, ...$this->getRulesNames($rule));
             }
 
             return $rulesNames;

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -138,7 +138,7 @@ class ValidatorTest extends TestCase
 
     public function testValue()
     {
-        $this->validator->value(2017, V::numeric()->between(2010, 2020), 'year');
+        $this->validator->value(2017, V::numericVal()->between(2010, 2020), 'year');
 
         $this->assertEquals(['year' => 2017], $this->validator->getValues());
         $this->assertTrue($this->validator->isValid());
@@ -147,7 +147,7 @@ class ValidatorTest extends TestCase
     public function testValidateWithErrors()
     {
         $this->validator->validate($this->request, [
-            'username' => V::length(8)
+            'username' => V::length(8, null, false)
         ]);
 
         $this->assertEquals(['username' => 'a_wurth'], $this->validator->getValues());
@@ -164,7 +164,7 @@ class ValidatorTest extends TestCase
     {
         $this->validator->setShowValidationRules(false);
         $this->validator->validate($this->request, [
-            'username' => V::length(8)
+            'username' => V::length(8, null, false)
         ]);
 
         $this->assertEquals(['username' => 'a_wurth'], $this->validator->getValues());
@@ -180,7 +180,7 @@ class ValidatorTest extends TestCase
     public function testValidateWithGroupedErrors()
     {
         $this->validator->validate($this->request, [
-            'username' => V::length(8)
+            'username' => V::length(8, null, false)
         ], 'user');
 
         $this->assertFalse($this->validator->isValid());
@@ -344,7 +344,7 @@ class ValidatorTest extends TestCase
                     'length' => 'Too short!'
                 ]
             ],
-            'password' => V::length(8)
+            'password' => V::length(8, null, false),
         ]);
 
         $this->assertEquals(['username' => 'a_wurth', 'password' => '1234'], $this->validator->getValues());
@@ -368,7 +368,7 @@ class ValidatorTest extends TestCase
                     'length' => 'Too short!'
                 ]
             ],
-            'password' => V::length(8)
+            'password' => V::length(8, null, false)
         ], 'user');
 
         $this->assertEquals([


### PR DESCRIPTION
I've upgraded the respect/validation library to 2.0 and made all necessary adaptations. Tests are working ok and in my project all validations are working ok too.