### PR TITLE
Correctly obtain arguments from Route

### DIFF
--- a/src/Validator.php
+++ b/src/Validator.php
@@ -15,6 +15,7 @@ use Psr\Http\Message\ServerRequestInterface as Request;
 use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validatable as RespectValidatable;
 use Slim\Interfaces\RouteInterface;
+use Slim\Routing\RouteContext;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 
@@ -190,9 +191,10 @@ class Validator
     {
         $postParams = $request->getParsedBody();
         $getParams = $request->getQueryParams();
-        $route = $request->getAttribute('route');
 
         $routeParams = [];
+        $routeContext = RouteContext::fromRequest($request);
+        $route = $routeContext->getRoute();
         if ($route instanceof RouteInterface) {
             $routeParams = $route->getArguments();
         }

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -15,6 +15,7 @@ use Psr\Http\Message\ServerRequestInterface as Request;
 use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validatable as RespectValidatable;
 use Slim\Interfaces\RouteInterface;
+use Slim\Routing\RouteContext;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 
@@ -193,8 +194,8 @@ class Validator
         $route = $request->getAttribute('route');
         $routeParams = [];
         
-        if (class_exists('\\Slim\\Routing\\RouteContext')) {
-            $routeContext = \Slim\Routing\RouteContext::fromRequest($request);
+        if (class_exists(RouteContext::class)) {
+            $routeContext = RouteContext::fromRequest($request);
             $route = $routeContext->getRoute();
         }
 

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -15,7 +15,6 @@ use Psr\Http\Message\ServerRequestInterface as Request;
 use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validatable as RespectValidatable;
 use Slim\Interfaces\RouteInterface;
-use Slim\Routing\RouteContext;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 
@@ -191,10 +190,14 @@ class Validator
     {
         $postParams = $request->getParsedBody();
         $getParams = $request->getQueryParams();
-
+        $route = $request->getAttribute('route');
         $routeParams = [];
-        $routeContext = RouteContext::fromRequest($request);
-        $route = $routeContext->getRoute();
+        
+        if (class_exists('\\Slim\\Routing\\RouteContext')) {
+            $routeContext = \Slim\Routing\RouteContext::fromRequest($request);
+            $route = $routeContext->getRoute();
+        }
+
         if ($route instanceof RouteInterface) {
             $routeParams = $route->getArguments();
         }


### PR DESCRIPTION
In Slim v4 the correct way to get parameters from the route is using `RouteContext` as explained in [the documentation](https://www.slimframework.com/docs/v4/objects/request.html#route-object)